### PR TITLE
Add SQL schema and docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# jsyslogd
+
+This project contains a simple Node based syslog collector with a React front‑end.
+
+## Database setup
+
+A PostgreSQL database named `jsyslogd` is required. Create the tables using
+`schema.sql` before starting the server:
+
+```bash
+psql -U postgres -d jsyslogd -f schema.sql
+```
+
+If you run PostgreSQL via Docker you can also mount the file into the container
+so the tables are created automatically (see `docker-compose.yml`).
+
+## Running
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm run start
+```
+
+The server expects the usual `PG*` environment variables for database access and
+`JWT_SECRET` for authentication.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: jsyslogd
+    volumes:
+      - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    ports:
+      - '5432:5432'

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS logs (
+    id SERIAL PRIMARY KEY,
+    hostname TEXT NOT NULL,
+    host_address TEXT,
+    facility TEXT,
+    severity TEXT,
+    tag TEXT,
+    message TEXT,
+    raw TEXT,
+    received_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- define `users` and `logs` tables in new `schema.sql`
- document database initialization steps in `README.md`
- provide a simple `docker-compose.yml` mounting the schema for auto init

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f90f39508833299490a09f958ccff